### PR TITLE
Add GitHub Actions workflow for Java CI with Gradle

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,73 @@
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@master
+
+      - name: Set up repository
+        uses: actions/checkout@master
+        with:
+          ref: master
+
+      - name: Merge to master
+        run: git checkout --progress --force ${{ github.sha }}
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: '17'
+          java-package: jdk+fx
+
+      - name: Build and check with Gradle
+        run: ./gradlew check
+
+      - name: Perform IO redirection test (*NIX)
+        if: runner.os == 'Linux'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        run: ./runtest.sh
+
+      - name: Perform IO redirection test (MacOS)
+        if: always() && runner.os == 'macOS'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        run: ./runtest.sh
+
+      - name: Perform IO redirection test (Windows)
+        if: always() && runner.os == 'Windows'
+        working-directory:  ${{ github.workspace }}/text-ui-test
+        shell: cmd
+        run: runtest.bat
+
+  dependency-submission:
+
+    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Generates and submits a dependency graph, enabling Dependabot Alerts for all project dependencies.
+      # See: https://github.com/gradle/actions/blob/main/dependency-submission/README.md
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0


### PR DESCRIPTION
There is no Continuous Integration (CI) in this Java project.

Commits to a PR may cause build or test failures against the default branch.

Let's add this .yml file to allow such problems to be observed, ensuring code functionality.

Refer to this article for more info
https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-java-with-gradle